### PR TITLE
odin: use qemu.sf.lcd_density

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -112,6 +112,7 @@ config.disable_rtt=true
 #Bringup properties
 persist.sys.force_sw_gles=1
 persist.vendor.radio.atfwd.start=true
+qemu.sf.lcd_density=440
 ro.kernel.qemu.gles=0
 qemu.hw.mainkeys=0
 #Expose aux camera for all packages


### PR DESCRIPTION
'qemu.sf.lcd_density' overrides xdpi and ydpi informations from framebuffer.
It's better to (ab)use 'qemu.sf.lcd_density' instead of patching frameworks/base.

Fixes image scaling in apps using https://github.com/davemorrissey/subsampling-scale-image-view, like Tachiyomi, Reddit, Sync for Reddit, Boost for Reddit.
---
Related issues:
https://github.com/davemorrissey/subsampling-scale-image-view/issues/536
https://github.com/tachiyomiorg/tachiyomi/issues/4131