### PR TITLE
odin: overlay: Adjust status bar height

### DIFF
--- a/overlay/FrameworksResOdin/res/values/dimens.xml
+++ b/overlay/FrameworksResOdin/res/values/dimens.xml
@@ -7,15 +7,15 @@
     <!-- Height of the status bar.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
          -->
-    <dimen name="status_bar_height_default">28dp</dimen>
+    <dimen name="status_bar_height_default">98px</dimen>
 
     <!-- Height of the status bar in portrait.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
          -->
-    <dimen name="status_bar_height_portrait">80px</dimen>
+    <dimen name="status_bar_height_portrait">@dimen/status_bar_height_default</dimen>
 
     <!-- Height of the status bar in landscape.
          Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
          -->
-    <dimen name="status_bar_height_landscape">@dimen/status_bar_height_default</dimen>
+    <dimen name="status_bar_height_landscape">28dp</dimen>
 </resources>


### PR DESCRIPTION
When the status bar height is too short, the rest of the view goes up into the CUP area causing colorful pixels to show around it especially when it has solid color and not transparent. Covering the CUP area by increasing the status bar height will prevent this from happening not always but most of the time.

On Stock MIUI ROM, the status bar height is taller that fills the CUP area.