### PR TITLE
Fix camera cutout position

### DIFF
--- a/cutout/src/com/arrow/cutoutringservice/CutoutRingService.java
+++ b/cutout/src/com/arrow/cutoutringservice/CutoutRingService.java
@@ -129,6 +129,7 @@ public class CutoutRingService extends BroadcastReceiver {
             @Override
             public void onFixedRotationStarted(int displayId, int newRotation) {
                 mFixedRotationInProgress = true;
+				Log.i(TAG, String.format("new rotation: %d", newRotation));
                 Handler.getMain().postAtFrontOfQueue(() -> setVisibility(HIDDEN));
             }
 
@@ -245,9 +246,18 @@ public class CutoutRingService extends BroadcastReceiver {
     }
 
     private void onRotationChanged() {
+        // Log immediate rotation state
+        int immediateRotation = getRotation();
+        Log.i(TAG, "Immediate rotation state: " + immediateRotation);
         adjustParamsToRotation();
-        Handler.getMain().postAtFrontOfQueue(() -> {
+        mWindowManager.updateViewLayout(mRingView, mRingParams);
+        
+        // Post a delayed check to log the state after a short delay
+        Handler.getMain().postDelayed(() -> {
+            int delayedRotation = getRotation();
+            Log.i(TAG, "Delayed rotation state: " + delayedRotation);
+            adjustParamsToRotation();
             mWindowManager.updateViewLayout(mRingView, mRingParams);
-        });
+        }, 1000);
     }
 }


### PR DESCRIPTION
This is an initial draft, the changes are untested (don't een know if they build yet lol). The idea now is to actually get the raw angle of the device and not rely on the logical rotation of the device as this can be flaky.
I also think we don't need the DisplayManager with this anymore, right? We are not listening to its events anymore.

What do you think?
I tested the concept with a small test app and it worked perfectly there :)